### PR TITLE
Change nanoseconds to microseconds in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ use in various ways. In summary:
     goes away in our microbenchmark if the program is pinned to a single core.
     So inter-core communication is something to watch out for.
 
--   Creating a new task takes ~300ns for an async task, versus ~17µs for a new
+-   Creating a new task takes ~0.3µs for an async task, versus ~17µs for a new
     kernel thread.
 
 -   Memory consumption per task (i.e. for a task that doesn't do much) starts at


### PR DESCRIPTION
Since all the other times in the README.md are expressed as microseconds as well, I think this change makes that sentence easier to put in perspective.